### PR TITLE
feat: add bind mount to fix obs configuration issue

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -34,3 +34,5 @@ RUN wget https://raw.githubusercontent.com/obsproject/obs-studio/master/UI/xdg-d
     wget https://raw.githubusercontent.com/obsproject/obs-studio/master/UI/xdg-data/icons/obs-logo-512.png -O /usr/share/icons/hicolor/512x512/apps/com.obsproject.Studio.png && \
     wget https://raw.githubusercontent.com/obsproject/obs-studio/master/UI/xdg-data/icons/obs-logo-scalable.svg -O /usr/share/icons/hicolor/scalable/apps/com.obsproject.Studio.svg && \
     sed -i 's@Exec=obs@Exec=/opt/obs-portable/obs-portable@g' /usr/share/applications/com.obsproject.Studio.desktop
+
+COPY obs-config-fix.sh /etc/profile.d/99-obs-config-fix.sh

--- a/obs-config-fix.sh
+++ b/obs-config-fix.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/bash
+
+home_dir="$(getent passwd $(id -u) | awk '{print $6}' FS=':')"
+OBS_CONFIG_DIR="/opt/obs-portable/config"
+OBS_USER_CONFIG_DIR="/run/host/${home_dir}/.config/obs-portable"
+
+if ! [ -d "${OBS_USER_CONFIG_DIR}" ]; then
+    mkdir "${OBS_USER_CONFIG_DIR}"
+fi
+
+if ! [ -d "${OBS_CONFIG_DIR}" ]; then
+    sudo mkdir "${OBS_CONFIG_DIR}"
+fi
+
+if ! findmnt "${OBS_CONFIG_DIR}" then
+    sudo mount --bind \
+        "${OBS_CONFIG_USER_DIR}" \
+        "${OBS_CONFIG_DIR}"
+fi


### PR DESCRIPTION
We drop a script in `/etc/profile.d/99-obs-config-fix.sh` and this will create the directory and set up the bind mount in the user's home directory.

From the perspective of the user the configuration will be pulled from the standard location from OBS.

If the user does not use BASH as login shell then they will need to call `/etc/profile.d/99-obs-config-fix.sh` manually before running OBS. (we can put that as `init_hook` as the script is meant to be idempotent)