### PR TITLE
Optimise dependencies for container composition 

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -23,7 +23,7 @@ RUN wget https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64 -O /us
         -O /tmp/obs-portable/latest.tar.bz2 && \
     tar xvf /tmp/obs-portable/latest.tar.bz2 -C /tmp/obs-portable --strip-components=1 && \
     rm /tmp/obs-portable/latest.tar.bz2 && \
-    yes | /tmp/obs-portable/obs-dependencies && \
+    /tmp/obs-portable/obs-container-dependencies && \
     mv /tmp/obs-portable /opt/obs-portable && \
     rm /usr/bin/jq
 


### PR DESCRIPTION
**NOTE: This is a breaking change until I release a new version of obs-studio-portable that includes the new dependency installer, but that is ready. But I want this project ready to receive.**

The new obs-container-dependencies is optimised for containers, it excludes kernel modules and associated DKMS build tools.

In addition, it includes upstream Pipewire and the required Gstreamer stack used by obs-streamer and obs-vaapi.

Installed dependencies should now be ~500MB as opposed to ~1100MB previously.