### PR TITLE
fix: update ubuntu 23.04 container URL

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/toolbx-images/ubuntu-toolbox:23.04 as obs-studio-portable
+FROM quay.io/toolbx/ubuntu-toolbox:23.04 as obs-studio-portable
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox or distrobox command" \


### PR DESCRIPTION
Ubuntu images are built in the toolbox repo, not toolbox-images.