### PR TITLE
Fix dependency installation

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,7 +19,7 @@ RUN wget https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64 -O /us
     mkdir -p /tmp/obs-portable && \
     wget \
         $(curl -s https://api.github.com/repos/wimpysworld/obs-studio-portable/releases/latest | \
-        jq -r ".assets[] | select(.name | test(\"ubuntu-$(lsb_release -rs).tar.bz2\")) | .browser_download_url") \
+        jq -r ".assets[] | select(.name | test(\"ubuntu-$(lsb_release -rs).tar.bz2\$\")) | .browser_download_url") \
         -O /tmp/obs-portable/latest.tar.bz2 && \
     tar xvf /tmp/obs-portable/latest.tar.bz2 -C /tmp/obs-portable --strip-components=1 && \
     rm /tmp/obs-portable/latest.tar.bz2 && \

--- a/Containerfile
+++ b/Containerfile
@@ -9,7 +9,7 @@ COPY ./extra-packages /extra-packages
 
 RUN apt-get update && \ 
     apt-get upgrade -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
         $(cat extra-packages | xargs) && \
     rm -rd /var/lib/apt/lists/*
 

--- a/extra-packages
+++ b/extra-packages
@@ -1,1 +1,2 @@
 bzip2
+software-properties-common


### PR DESCRIPTION
This pull requests updates `extra-packages` to include `software-properties-common` that is required by `obs-container-dependencies`.  `extra-packages` is also now installed without recommended packages.