### PR TITLE
Remove software-properties-common

### DIFF
--- a/extra-packages
+++ b/extra-packages
@@ -4,4 +4,3 @@ dialog
 libegl1-mesa
 libgl1-mesa-glx
 libvte-2.91-common
-software-properties-common


### PR DESCRIPTION
The upstream project has been optimised to not require `software-properties-common`, this helps reduce the container size.