### PR TITLE
Update base image to Ubuntu 24.04

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/toolbx/ubuntu-toolbox:23.04 as obs-studio-portable
+FROM quay.io/toolbx/ubuntu-toolbox:24.04 as obs-studio-portable
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox or distrobox command" \


### PR DESCRIPTION
Ubuntu 23.04 is EOL and distrobox will fail to create new container during "installing additional packages" phase of creation as the apt repositories for 23.04 will return 404.

 This issue also causes `ujust update` to skip updating distrobox containers due to the error.